### PR TITLE
Use protocol-relative URLs for loading the facebook and twitter scripts

### DIFF
--- a/scripts/jquery.socialshareprivacy.facebook.js
+++ b/scripts/jquery.socialshareprivacy.facebook.js
@@ -75,7 +75,7 @@
 				params.layout = 'box_count';
 			}
 			return $('<iframe scrolling="no" frameborder="0" allowtransparency="true"></iframe>').attr(
-				'src','http://www.facebook.com/plugins/like.php?'+$.param(params));
+				'src','//www.facebook.com/plugins/like.php?'+$.param(params));
 		}
 	};
 })(jQuery);

--- a/scripts/jquery.socialshareprivacy.twitter.js
+++ b/scripts/jquery.socialshareprivacy.twitter.js
@@ -55,7 +55,7 @@
 			if (options.dnt)      params.dnt      = options.dnt;
 
 			return $('<iframe allowtransparency="true" frameborder="0" scrolling="no"></iframe>').attr(
-				'src', 'http://platform.twitter.com/widgets/tweet_button.html?' +
+				'src', '//platform.twitter.com/widgets/tweet_button.html?' +
 				$.param(params).replace(/\+/g,'%20'));
 		}
 	};


### PR DESCRIPTION
So as to not break the "https" lock icon due to loading non-SSL content on my SSL-enabled web site.

Tested on https://hackerbruecke.io/thread/b1ccdc39-8adb-4afc-913f-a20571bb77e7
