### PR TITLE
Facebook box width is 48px

### DIFF
--- a/javascripts/modules/facebook.js
+++ b/javascripts/modules/facebook.js
@@ -70,7 +70,7 @@
 				params.layout = 'button_count';
 			}
 			else {
-				params.width  = '62';
+				params.width  = '48';
 				params.height = '61';
 				params.layout = 'box_count';
 			}

--- a/stylesheets/modules/facebook.css
+++ b/stylesheets/modules/facebook.css
@@ -7,6 +7,6 @@
 	height: 21px;
 }
 .social_share_privacy_area.box .facebook iframe {
-	width: 62px;
+	width: 48px;
 	height: 62px;
 }


### PR DESCRIPTION
Even if you specify more in the URL params, Facebook's widget is only 48px wide.
